### PR TITLE
Update layout.scss

### DIFF
--- a/assets/scss/organisms/layout.scss
+++ b/assets/scss/organisms/layout.scss
@@ -81,6 +81,7 @@
             .loading.complete {
                 opacity: 0;
                 z-index: 1;
+                visibility: hidden;
             }
 
     }


### PR DESCRIPTION
Inserção da propriedade "visibility: hidden" no seletor ".loading.complete" para habilitar os links no rodapé que estão desabilitados por causa da propriedade "z-index: 1". Desta forma, a div.loading fica acima do conteúdo.
